### PR TITLE
WIN: allow pytables >3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --ignore-installed --no-deps .
 
 requirements:
@@ -36,7 +36,9 @@ requirements:
     - numba
     - lmfit
     - phconvert
-    - pytables <3.4  # [win]
+    - pytables
+    # Fix pytables on windows. See https://github.com/conda-forge/pytables-feedstock/issues/31#issuecomment-410695814
+    - snappy  # [win]
 
 test:
   imports:


### PR DESCRIPTION
Trying installing snappy on windows as indicated here:
https://github.com/conda-forge/pytables-feedstock/issues/31#issuecomment-410695814

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
